### PR TITLE
Increment elastic CPU to use double

### DIFF
--- a/helm/etl/values.production.yaml
+++ b/helm/etl/values.production.yaml
@@ -7,7 +7,7 @@ db:
     enabled: true
 
 elasticsearch:
-  resources: {"requests": {"cpu": "25m", "memory": "2Gi"}, "limits": {"memory": "4Gi"}}
+  resources: {"requests": {"cpu": "50m", "memory": "2Gi"}, "limits": {"memory": "4Gi"}}
   nfsPath: "/srm/etl-production/elasticsearch"
   secretName: "elasticsearch"
   ES_JAVA_OPTS: "-Xms2048m -Xmx2048m"

--- a/helm/etl/values.staging.yaml
+++ b/helm/etl/values.staging.yaml
@@ -5,7 +5,7 @@ db:
   nfsPath: "/srm/etl-staging/db"
 
 elasticsearch:
-  resources: {"requests": {"cpu": "25m", "memory": "2Gi"}, "limits": {"memory": "4Gi"}}
+  resources: {"requests": {"cpu": "50m", "memory": "2Gi"}, "limits": {"memory": "4Gi"}}
   nfsPath: "/srm/etl-staging/elasticsearch"
   secretName: "elasticsearch"
   ES_JAVA_OPTS: "-Xms2048m -Xmx2048m"


### PR DESCRIPTION
The upload to DB keeps falling during lack of CPU usage. Increasing this would solve the problems and will allow fluent uploads to DB.